### PR TITLE
fix: JWT토큰 만료시 리프래쉬 토큰으로 재발급 안되던 문제 해결

### DIFF
--- a/src/main/java/com/capstone/shop/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/shop/config/SecurityConfig.java
@@ -6,6 +6,8 @@ import com.capstone.shop.security.TokenAuthenticationFilter;
 import com.capstone.shop.security.TokenProvider;
 import com.capstone.shop.security.oauth2.CustomOAuth2UserService;
 import com.capstone.shop.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
+import com.capstone.shop.user.v1.repository.UserRefreshTokenRepository;
+import com.capstone.shop.user.v1.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,9 +39,11 @@ public class SecurityConfig {
 
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final UserRefreshTokenRepository userRefreshTokenRepository;
+    private final UserRepository userRepository;
     @Bean
     public TokenAuthenticationFilter tokenAuthenticationFilter() {
-        return new TokenAuthenticationFilter(tokenProvider, customUserDetailsService);
+        return new TokenAuthenticationFilter(tokenProvider, customUserDetailsService, userRefreshTokenRepository,userRepository);
     }
     @Bean
     public HttpCookieOAuth2AuthorizationRequestRepository cookieAuthorizationRequestRepository() {
@@ -54,18 +58,24 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(authorize -> authorize
+                        //배포시에는 허용 url 바꿔야 합니다.
                         .requestMatchers(
+                                "**",
                                 "/",
-                                "/local/redirect",
-                                "/signin",
-                                "/signup",
-                                "/favicon.ico",
-                                "/oauth2/authorize",
-                                "/oauth2/authorization/*",
-                                "/login/oauth2/code/*",
-                                "/api/v1/**",
-                                "/static/**",
-                                "/assets/**"
+                                "local/redirect",
+                                "login/oauth2/code/*",
+                                "signin",
+                                "signup",
+                                "favicon.ico",
+                                "oauth2/authorize",
+                                "oauth2/authorization/*",
+                                "login/oauth2/code/*",
+                                "api/v1/user/**",
+                                "api/v1/merchandise/*",
+                                "api/v1/admin",
+                                "api/v1/user/me",
+                                "static/**",
+                                "assets/**"
                         ).permitAll()
                         .requestMatchers(
                                 "/*.png",

--- a/src/main/java/com/capstone/shop/entity/Image.java
+++ b/src/main/java/com/capstone/shop/entity/Image.java
@@ -1,5 +1,6 @@
 package com.capstone.shop.entity;
 
+import com.capstone.shop.enums.PictureType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/capstone/shop/entity/User.java
+++ b/src/main/java/com/capstone/shop/entity/User.java
@@ -1,5 +1,7 @@
 package com.capstone.shop.entity;
 
+import com.capstone.shop.enums.AuthProvider;
+import com.capstone.shop.enums.Role;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 
@@ -54,7 +56,7 @@ public class User {
     @Column(name = "role", length = 20)
     @Enumerated(EnumType.STRING)
     @NotNull
-    private Role role;
+    private Role role = Role.USER;
 
     @Column(name = "auth_provider", length = 20)
     @Enumerated(EnumType.STRING)
@@ -72,6 +74,9 @@ public class User {
     @Column(name = "MODIFIED_AT")
     private LocalDateTime modifiedAt;
 
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private UserRefreshToken userRefreshToken;
+
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now(); // 생성 시 현재 시간으로 설정
@@ -87,9 +92,11 @@ public class User {
             @NotNull @Size(max = 12) String name,
             @NotNull @Size(max = 100) String email,
             @NotNull AuthProvider authProvider
+            //@NotNull Role role
     ) {
         this.name = name;
         this.password = "NO_PASS"; //소셜로그인은 패스워드가 없음
         this.email = email != null ? email : "NO_EMAIL";
+        this.authProvider = authProvider;
     }
 }

--- a/src/main/java/com/capstone/shop/entity/UserRefreshToken.java
+++ b/src/main/java/com/capstone/shop/entity/UserRefreshToken.java
@@ -23,10 +23,14 @@ public class UserRefreshToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long refreshTokenSeq;
 
-    @Column(name = "USER_ID", length = 64, unique = true)
-    @NotNull
-    @Size(max = 64)
-    private String userId;
+    @OneToOne
+    @JoinColumn(name = "USER_ID", referencedColumnName = "id", nullable = false)
+    private User user;
+
+//    @Column(name = "USER_ID", length = 64, unique = true)
+//    @NotNull
+//    @Size(max = 64)
+//    private Long userId;
 
     @Column(name = "REFRESH_TOKEN", length = 256)
     @NotNull
@@ -34,10 +38,10 @@ public class UserRefreshToken {
     private String refreshToken;
 
     public UserRefreshToken(
-            @NotNull @Size(max = 64) String userId,
+            @NotNull @Size(max = 64) User user,
             @NotNull @Size(max = 256) String refreshToken
     ) {
-        this.userId = userId;
+        this.user = user;
         this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/capstone/shop/enums/AuthProvider.java
+++ b/src/main/java/com/capstone/shop/enums/AuthProvider.java
@@ -1,4 +1,4 @@
-package com.capstone.shop.entity;
+package com.capstone.shop.enums;
 
 import lombok.Getter;
 

--- a/src/main/java/com/capstone/shop/enums/PictureType.java
+++ b/src/main/java/com/capstone/shop/enums/PictureType.java
@@ -1,4 +1,4 @@
-package com.capstone.shop.entity;
+package com.capstone.shop.enums;
 
 public enum PictureType {
     MERCHANTDISE

--- a/src/main/java/com/capstone/shop/enums/Role.java
+++ b/src/main/java/com/capstone/shop/enums/Role.java
@@ -1,4 +1,4 @@
-package com.capstone.shop.entity;
+package com.capstone.shop.enums;
 
 public enum Role {
     USER,ADMIN

--- a/src/main/java/com/capstone/shop/security/TokenProvider.java
+++ b/src/main/java/com/capstone/shop/security/TokenProvider.java
@@ -40,7 +40,16 @@ public class TokenProvider {
                 .setExpiration(refreshExpiry) // 만료 시간 설정
                 .compact();
     }
-
+    public String createNewRefreshToken(Long userId) {
+        Date now = new Date();
+        Date refreshExpiry = new Date(now.getTime() + 604800000L); // 7일
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .setIssuedAt(now)
+                .setExpiration(refreshExpiry)
+                .signWith(SignatureAlgorithm.HS512, secret)
+                .compact();
+    }
     public String createAccessTokenFromRefreshToken(String refreshToken) {
         Claims claims = Jwts.parser()
                 .setSigningKey(secret)

--- a/src/main/java/com/capstone/shop/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/capstone/shop/security/oauth2/CustomOAuth2UserService.java
@@ -1,7 +1,7 @@
 package com.capstone.shop.security.oauth2;
 
 import com.capstone.shop.exception.OAuthProviderMissMatchException;
-import com.capstone.shop.entity.AuthProvider;
+import com.capstone.shop.enums.AuthProvider;
 import com.capstone.shop.entity.User;
 import com.capstone.shop.user.v1.repository.UserRepository;
 import com.capstone.shop.security.UserPrincipal;
@@ -40,8 +40,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private OAuth2User process(OAuth2UserRequest userRequest, OAuth2User user) {
         AuthProvider authProvider = AuthProvider.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase());
-
         OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(authProvider, user.getAttributes());
+        //debug
+        System.out.println("User Info: " + userInfo);
+        System.out.println("Profile Image: " + userInfo.getProfileImages());
+
         Optional<User> optionalUser = userRepository.findByEmail(userInfo.getEmail());
         User savedUser = optionalUser.orElse(null);
         //TODO: 예외처리
@@ -77,10 +80,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             user.setName(userInfo.getName());
         }
 
-        if (userInfo.getImageUrl() != null && !user.getProfileImages().equals(userInfo.getImageUrl())) {
-            user.setProfileImages(userInfo.getImageUrl());
+        if (userInfo.getProfileImages() != null) {
+            user.setProfileImages(userInfo.getProfileImages());
         }
 
-        return user;
+        return userRepository.save(user);
     }
 }

--- a/src/main/java/com/capstone/shop/security/oauth2/user/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/capstone/shop/security/oauth2/user/GoogleOAuth2UserInfo.java
@@ -14,8 +14,11 @@ public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
     public String getEmail() {
         return (String) attributes.get("email");
     }
+
+
+
     @Override
-    public String getImageUrl() {
+    public String getProfileImages() {
         return (String) attributes.get("picture");
     }
 

--- a/src/main/java/com/capstone/shop/security/oauth2/user/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/capstone/shop/security/oauth2/user/KakaoOAuth2UserInfo.java
@@ -31,7 +31,7 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo{
     }
 
     @Override
-    public String getImageUrl() {
+    public String getProfileImages() {
         Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
 
         if (properties == null) {

--- a/src/main/java/com/capstone/shop/security/oauth2/user/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/capstone/shop/security/oauth2/user/NaverOAuth2UserInfo.java
@@ -20,9 +20,11 @@ public class NaverOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
-    public String getImageUrl() {
+    public String getProfileImages() {
+        System.out.println("debug : "+(String) attributes.get("profile_image"));
         return (String) attributes.get("profile_image");
     }
+    //response/profile_image
 
     @Override
     public String getFirstName() {

--- a/src/main/java/com/capstone/shop/security/oauth2/user/OAuth2UserInfo.java
+++ b/src/main/java/com/capstone/shop/security/oauth2/user/OAuth2UserInfo.java
@@ -12,7 +12,7 @@ public abstract class OAuth2UserInfo {
 
     public abstract String getName();
     public abstract String getEmail();
-    public abstract String getImageUrl();
+    public abstract String getProfileImages();
 
     public abstract String getFirstName();
 

--- a/src/main/java/com/capstone/shop/security/oauth2/user/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/capstone/shop/security/oauth2/user/OAuth2UserInfoFactory.java
@@ -1,6 +1,6 @@
 package com.capstone.shop.security.oauth2.user;
 
-import com.capstone.shop.entity.AuthProvider;
+import com.capstone.shop.enums.AuthProvider;
 
 import java.util.Map;
 

--- a/src/main/java/com/capstone/shop/user/v1/controller/AuthController.java
+++ b/src/main/java/com/capstone/shop/user/v1/controller/AuthController.java
@@ -13,16 +13,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/ap1/v1/user")
 public class AuthController {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;

--- a/src/main/java/com/capstone/shop/user/v1/controller/MerchandiseController.java
+++ b/src/main/java/com/capstone/shop/user/v1/controller/MerchandiseController.java
@@ -1,8 +1,8 @@
 package com.capstone.shop.user.v1.controller;
 
-import com.capstone.shop.user.v1.dto.MerchandisePaginationResponse;
-import com.capstone.shop.user.v1.dto.MerchandiseRegisterRequest;
-import com.capstone.shop.user.v1.dto.MerchandiseResponse;
+import com.capstone.shop.user.v1.controller.dto.merchandise.MerchandisePaginationResponse;
+import com.capstone.shop.user.v1.controller.dto.merchandise.MerchandiseRegisterRequest;
+import com.capstone.shop.user.v1.controller.dto.merchandise.MerchandiseResponse;
 import com.capstone.shop.user.v1.dto.PaginationResponse;
 import com.capstone.shop.user.v1.service.MerchandiseService;
 import com.capstone.shop.entity.Merchandise;

--- a/src/main/java/com/capstone/shop/user/v1/controller/dto/merchandise/MerchandisePaginationResponse.java
+++ b/src/main/java/com/capstone/shop/user/v1/controller/dto/merchandise/MerchandisePaginationResponse.java
@@ -1,9 +1,10 @@
-package com.capstone.shop.user.v1.dto;
+package com.capstone.shop.user.v1.controller.dto.merchandise;
 
 import java.util.List;
+
+import com.capstone.shop.user.v1.dto.PaginationResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @AllArgsConstructor
 @Getter

--- a/src/main/java/com/capstone/shop/user/v1/controller/dto/merchandise/MerchandiseRegisterRequest.java
+++ b/src/main/java/com/capstone/shop/user/v1/controller/dto/merchandise/MerchandiseRegisterRequest.java
@@ -1,4 +1,4 @@
-package com.capstone.shop.user.v1.dto;
+package com.capstone.shop.user.v1.controller.dto.merchandise;
 
 import com.capstone.shop.entity.Merchandise;
 import java.util.List;

--- a/src/main/java/com/capstone/shop/user/v1/controller/dto/merchandise/MerchandiseResponse.java
+++ b/src/main/java/com/capstone/shop/user/v1/controller/dto/merchandise/MerchandiseResponse.java
@@ -1,4 +1,4 @@
-package com.capstone.shop.user.v1.dto;
+package com.capstone.shop.user.v1.controller.dto.merchandise;
 
 import com.capstone.shop.entity.Image;
 import com.capstone.shop.entity.Merchandise;

--- a/src/main/java/com/capstone/shop/user/v1/dto/SignUpRequest.java
+++ b/src/main/java/com/capstone/shop/user/v1/dto/SignUpRequest.java
@@ -1,7 +1,7 @@
 package com.capstone.shop.user.v1.dto;
 
-import com.capstone.shop.entity.AuthProvider;
-import com.capstone.shop.entity.Role;
+import com.capstone.shop.enums.AuthProvider;
+import com.capstone.shop.enums.Role;
 import com.capstone.shop.entity.User;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/capstone/shop/user/v1/repository/UserRefreshTokenRepository.java
+++ b/src/main/java/com/capstone/shop/user/v1/repository/UserRefreshTokenRepository.java
@@ -4,6 +4,8 @@ import com.capstone.shop.entity.UserRefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
-    UserRefreshToken findByUserId(String userId);
-    UserRefreshToken findByUserIdAndRefreshToken(String userId, String refreshToken);
+    UserRefreshToken findByUserEmail(String userEmail);
+
+    UserRefreshToken findByUserId(Long id);
+    UserRefreshToken findByUserIdAndRefreshToken(Long userId, String refreshToken);
 }

--- a/src/main/java/com/capstone/shop/user/v1/service/AuthService.java
+++ b/src/main/java/com/capstone/shop/user/v1/service/AuthService.java
@@ -2,8 +2,8 @@ package com.capstone.shop.user.v1.service;
 
 import com.capstone.shop.user.v1.dto.OAuth2AdditionalInfoRequest;
 import com.capstone.shop.user.v1.dto.SignUpRequest;
-import com.capstone.shop.entity.AuthProvider;
-import com.capstone.shop.entity.Role;
+import com.capstone.shop.enums.AuthProvider;
+import com.capstone.shop.enums.Role;
 
 import java.util.Map;
 

--- a/src/main/java/com/capstone/shop/user/v1/service/RefreshTokenService.java
+++ b/src/main/java/com/capstone/shop/user/v1/service/RefreshTokenService.java
@@ -1,5 +1,6 @@
 package com.capstone.shop.user.v1.service;
 
+import com.capstone.shop.entity.User;
 import com.capstone.shop.entity.UserRefreshToken;
 import com.capstone.shop.user.v1.repository.UserRefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,22 +11,22 @@ import org.springframework.stereotype.Service;
 public class RefreshTokenService {
     private final UserRefreshTokenRepository refreshTokenRepository;
 
-    public void saveRefreshToken(String userId, String refreshToken) {
-        UserRefreshToken userRefreshToken = refreshTokenRepository.findByUserId(userId);
+    public void saveRefreshToken(User user, String refreshToken) {
+        UserRefreshToken userRefreshToken = refreshTokenRepository.findByUserId(user.getId());
         if (userRefreshToken != null) {
             userRefreshToken.setRefreshToken(refreshToken);
         } else {
-            userRefreshToken = new UserRefreshToken(userId, refreshToken);
+            userRefreshToken = new UserRefreshToken(user, refreshToken);
         }
         refreshTokenRepository.save(userRefreshToken);
     }
 
-    public boolean verifyRefreshToken(String userId, String refreshToken) {
+    public boolean verifyRefreshToken(Long userId, String refreshToken) {
         UserRefreshToken userRefreshToken = refreshTokenRepository.findByUserIdAndRefreshToken(userId, refreshToken);
         return userRefreshToken != null;  //true or false 반환
     }
 
-    public void deleteRefreshToken(String userId) {
+    public void deleteRefreshToken(Long userId) {
         UserRefreshToken userRefreshToken = refreshTokenRepository.findByUserId(userId);
         if (userRefreshToken != null) {
             refreshTokenRepository.delete(userRefreshToken);

--- a/src/main/java/com/capstone/shop/util/JwtTokenUtil.java
+++ b/src/main/java/com/capstone/shop/util/JwtTokenUtil.java
@@ -46,11 +46,11 @@ public class JwtTokenUtil implements Serializable {
         return expiration.before(new Date());
     }
 
-    //generate token for user (토큰 생성)
-    public String generateToken(Long userId) {
-        Map<String, Object> claims = new HashMap<>();
-        return doGenerateToken(claims, userId.toString());
-    }
+    //generate token for user (토큰 생성) 이건 로컬 auth와 같은 로직으로 사용하기로 했음. 241030
+//    public String generateToken(Long userId) {
+//        Map<String, Object> claims = new HashMap<>();
+//        return doGenerateToken(claims, userId.toString());
+//    }
 
     //while creating the token - (토큰에 정보를 넣고, 시크릿 키를 이용해서 토큰을 compact하게 만든다)
     //1. Define  claims of the token, like Issuer, Expiration, Subject, and the ID


### PR DESCRIPTION

fix: 소셜 회원가입 시 AuthProvider, profile_image가 null로 들어가던 문제 해결

User엔티티의 생성자에 AuthProvider 추가, CustomOAuth2UserService클래스의 updateUser메서드에서 save메서드 추가

fix: User엔티티와 UserRefreshToken엔티티 OneToOne연관관계 추가

User가 삭제되어도 토큰이 그대로 db에 남아 성능 저하 우려 -> 연관관계 추가로 User가 삭제되면 토큰도 삭제되도록 함.